### PR TITLE
[Feature] Implement <FloatingButton> to control drawer

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -18,5 +18,11 @@
       "matches": ["<all_urls>"],
       "js": ["content.js"]
     }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["*"],
+      "matches": ["<all_urls>"]
+    }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "re-resizable": "^6.9.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-draggable": "^4.4.4",
     "react-hot-loader": "^4.13.0",
     "react-icons": "^4.2.0",
     "react-query": "^3.19.1",

--- a/src/App.js
+++ b/src/App.js
@@ -2,16 +2,23 @@ import MainDrawer from 'components/MainDrawer'
 import usePageInfo from 'hooks/pageInfo/usePageInfo'
 import FileSearchModal from 'components/FileSearchModal'
 import { useSettingStateCtx } from 'components/Setting/Context/Provider'
+import FloatingButton from 'components/FloatingButton'
 import GlobalStyle from './GlobalStyle'
 
 function App() {
   const { error, isLoading, pageInfo } = usePageInfo()
-  const { drawerWidth } = useSettingStateCtx()
+  const { drawerWidth, drawerPinned } = useSettingStateCtx()
 
   return (
     <>
-      <GlobalStyle pl={drawerWidth} />
-      <MainDrawer {...pageInfo} error={error} isLoading={isLoading} />
+      <FloatingButton />
+      <GlobalStyle pl={drawerPinned ? drawerWidth : 0} />
+      <MainDrawer
+        {...pageInfo}
+        error={error}
+        isLoading={isLoading}
+        open={drawerPinned}
+      />
       <FileSearchModal {...pageInfo} />
     </>
   )

--- a/src/components/FloatingButton/index.js
+++ b/src/components/FloatingButton/index.js
@@ -1,0 +1,79 @@
+import React, { useMemo } from 'react'
+import Box from '@material-ui/core/Box'
+import Draggable from 'react-draggable'
+import { useSettingCtx } from 'components/Setting/Context/Provider'
+
+const HEIGHT = 50
+
+const FloatingButton = () => {
+  const [{ floatingButtonPositionY }, dispatch] = useSettingCtx()
+
+  // Memorized original position y because the implementation of `react-draggable` is
+  // to use `transform` to control the element, if we update position y immediately,
+  // the position y would be doubled (position Y + transform Y),
+  // so we need to keep original Y to make <Draggable> controllable and
+  // update local storage's Y as soon as we finished dragging.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const originalPositionY = useMemo(() => floatingButtonPositionY, [])
+
+  const url = window.chrome.runtime.getURL('icon192.png')
+
+  return (
+    <Box position="fixed" top={originalPositionY} left={0} zIndex={2100}>
+      <Draggable
+        axis="y"
+        defaultPosition={{ x: 0, y: 0 }}
+        handle="span"
+        onStop={(_, { y }) => {
+          dispatch({
+            type: 'UPDATE_FLOATING_BUTTON_POSITION_Y',
+            payload: y + originalPositionY,
+          })
+        }}
+      >
+        <Box
+          width={50}
+          height={HEIGHT}
+          bgcolor="#252a2e"
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          borderRadius="0 5px 5px 0"
+          style={{
+            cursor: 'pointer',
+          }}
+          onClick={() => {
+            dispatch({ type: 'TOGGLE_DRAWER' })
+          }}
+        >
+          <Box
+            component="img"
+            src={url}
+            width={30}
+            height={30}
+            style={{
+              userSelect: 'none',
+              userDrag: 'none',
+            }}
+          />
+          <Box
+            position="absolute"
+            width={20}
+            height={HEIGHT}
+            top={0}
+            left={0}
+            component="span"
+            style={{
+              cursor: 'move',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          />
+        </Box>
+      </Draggable>
+    </Box>
+  )
+}
+
+FloatingButton.propTypes = {}
+
+export default FloatingButton

--- a/src/components/FloatingButton/index.js
+++ b/src/components/FloatingButton/index.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import Box from '@material-ui/core/Box'
 import Draggable from 'react-draggable'
 import { useSettingCtx } from 'components/Setting/Context/Provider'
@@ -7,6 +7,7 @@ const HEIGHT = 50
 
 const FloatingButton = () => {
   const [{ floatingButtonPositionY }, dispatch] = useSettingCtx()
+  const [isDragging, setIsDragging] = useState(false)
 
   // Memorized original position y because the implementation of `react-draggable` is
   // to use `transform` to control the element, if we update position y immediately,
@@ -19,7 +20,17 @@ const FloatingButton = () => {
   const url = window.chrome.runtime.getURL('icon192.png')
 
   return (
-    <Box position="fixed" top={originalPositionY} left={0} zIndex={2100}>
+    <Box
+      position="fixed"
+      top={originalPositionY}
+      left={0}
+      zIndex={2100}
+      onMouseUp={() => {
+        if (isDragging) return
+
+        dispatch({ type: 'TOGGLE_DRAWER' })
+      }}
+    >
       <Draggable
         axis="y"
         defaultPosition={{ x: 0, y: 0 }}
@@ -42,9 +53,6 @@ const FloatingButton = () => {
           style={{
             cursor: 'pointer',
           }}
-          onClick={() => {
-            dispatch({ type: 'TOGGLE_DRAWER' })
-          }}
         >
           <Box
             component="img"
@@ -58,7 +66,7 @@ const FloatingButton = () => {
           />
           <Box
             position="absolute"
-            width={20}
+            width={50}
             height={HEIGHT}
             top={0}
             left={0}
@@ -66,7 +74,8 @@ const FloatingButton = () => {
             style={{
               cursor: 'move',
             }}
-            onClick={(e) => e.stopPropagation()}
+            onMouseDown={() => setIsDragging(false)}
+            onMouseMove={() => setIsDragging(true)}
           />
         </Box>
       </Draggable>

--- a/src/components/FloatingButton/index.js
+++ b/src/components/FloatingButton/index.js
@@ -3,7 +3,10 @@ import Box from '@material-ui/core/Box'
 import Draggable from 'react-draggable'
 import { useSettingCtx } from 'components/Setting/Context/Provider'
 
-const HEIGHT = 50
+const HEIGHT = 40
+const WIDTH = 40
+
+const IMG_WIDTH = 25
 
 const FloatingButton = () => {
   const [{ floatingButtonPositionY }, dispatch] = useSettingCtx()
@@ -49,7 +52,7 @@ const FloatingButton = () => {
         }}
       >
         <Box
-          width={50}
+          width={WIDTH}
           height={HEIGHT}
           bgcolor="#252a2e"
           display="flex"
@@ -63,8 +66,8 @@ const FloatingButton = () => {
           <Box
             component="img"
             src={url}
-            width={30}
-            height={30}
+            width={IMG_WIDTH}
+            height={IMG_WIDTH}
             style={{
               userSelect: 'none',
               userDrag: 'none',
@@ -72,7 +75,7 @@ const FloatingButton = () => {
           />
           <Box
             position="absolute"
-            width={50}
+            width={WIDTH}
             height={HEIGHT}
             top={0}
             left={0}

--- a/src/components/FloatingButton/index.js
+++ b/src/components/FloatingButton/index.js
@@ -15,7 +15,13 @@ const FloatingButton = () => {
   // so we need to keep original Y to make <Draggable> controllable and
   // update local storage's Y as soon as we finished dragging.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const originalPositionY = useMemo(() => floatingButtonPositionY, [])
+  const originalPositionY = useMemo(
+    () =>
+      // >=1 is impossible, means the data is dirty, should reset it to prevent button missing
+      (floatingButtonPositionY >= 1 ? 0.5 : floatingButtonPositionY) *
+      window.innerHeight,
+    []
+  )
 
   const url = window.chrome.runtime.getURL('icon192.png')
 
@@ -38,7 +44,7 @@ const FloatingButton = () => {
         onStop={(_, { y }) => {
           dispatch({
             type: 'UPDATE_FLOATING_BUTTON_POSITION_Y',
-            payload: y + originalPositionY,
+            payload: (y + originalPositionY) / window.innerHeight,
           })
         }}
       >

--- a/src/components/MainDrawer/index.js
+++ b/src/components/MainDrawer/index.js
@@ -36,6 +36,7 @@ const MainDrawer = ({
   defaultBranch,
   error,
   isLoading,
+  open,
 }) => {
   const [{ drawerWidth }, dispatch] = useSettingCtx()
   const classes = useStyles()
@@ -94,18 +95,16 @@ const MainDrawer = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const handleOnResize = useCallback(
     throttle((_, __, element) => {
-      const width = element.clientWidth < 200 ? 5 : element.clientWidth
-
       dispatch({
         type: 'UPDATE_DRAWER_WIDTH',
-        payload: width,
+        payload: element.clientWidth,
       })
     }, 100),
     []
   )
 
   return (
-    <Drawer anchor="left" open variant="permanent" classes={classes}>
+    <Drawer anchor="left" open={open} variant="persistent" classes={classes}>
       <ResizableWrapper
         drawerWidth={drawerWidth}
         handleOnResize={handleOnResize}

--- a/src/components/Setting/Context/reducer.js
+++ b/src/components/Setting/Context/reducer.js
@@ -19,7 +19,7 @@ export const initialState = {
   drawerWidth: 300,
   drawerPinned: true,
   domains: [],
-  floatingButtonPositionY: 40,
+  floatingButtonPositionY: 0.5, // percent
 }
 
 /**

--- a/src/components/Setting/Context/reducer.js
+++ b/src/components/Setting/Context/reducer.js
@@ -17,7 +17,9 @@ export const initialState = {
   position: LEFT,
   isFocusMode: false,
   drawerWidth: 300,
-  domains: []
+  drawerPinned: true,
+  domains: [],
+  floatingButtonPositionY: 40,
 }
 
 /**
@@ -38,6 +40,10 @@ export const reducer = (state, action) => {
       return { ...state, drawerWidth: action.payload }
     case 'UPDATE_BASE_URL':
       return { ...state, baseUrl: action.payload }
+    case 'UPDATE_FLOATING_BUTTON_POSITION_Y':
+      return { ...state, floatingButtonPositionY: action.payload }
+    case 'TOGGLE_DRAWER':
+      return { ...state, drawerPinned: !state.drawerPinned }
     default:
       throw new Error(`Unknown Type: ${action.type}`)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,9 @@ const checkDomainMatched = (domains) => {
   return domains.includes(host) || host === 'github.com'
 }
 
-const applyStyleFromLocalStorage = (drawerWidth) => {
+const applyStyleFromLocalStorage = (drawerPinned, drawerWidth) => {
+  if (!drawerPinned) return
+
   const style = document.createElement('style')
   style.innerHTML = `
     html {
@@ -65,11 +67,11 @@ const createContainer = () => {
 }
 
 const renderExtension = () => {
-  const { drawerWidth, domains } = getSettingFromLocalStorage()
+  const { drawerWidth, drawerPinned, domains } = getSettingFromLocalStorage()
 
   if (!checkDomainMatched(domains)) return
 
-  applyStyleFromLocalStorage(drawerWidth)
+  applyStyleFromLocalStorage(drawerPinned, drawerWidth)
 
   const onLoad = () => {
     const queryClient = new QueryClient()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2135,7 +2135,7 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
-clsx@^1.0.4:
+clsx@^1.0.4, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -4643,7 +4643,7 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prop-types@15.7.2, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -4734,6 +4734,14 @@ react-dom@^17.0.2:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     scheduler "^0.20.2"
+
+react-draggable@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.4.tgz#5b26d9996be63d32d285a426f41055de87e59b2f"
+  integrity sha512-6e0WdcNLwpBx/YIDpoyd2Xb04PB0elrDrulKUgdrIlwuYvxh5Ok9M+F8cljm8kPXXs43PmMzek9RrB1b7mLMqA==
+  dependencies:
+    clsx "^1.1.1"
+    prop-types "^15.6.0"
 
 react-focus-lock@2.5.2:
   version "2.5.2"


### PR DESCRIPTION
### Description
implement floating button to control drawer

### Changes
1. implement floating button
2. remove the function that if you resize drawer's width < 200, the width would be reset to 0 automatically
3. solution to importing images in chrome extension by using react

### How do we test
Floating button:
1. floating button should be draggable. the draggable area whole button
2. clicking button should toggle drawer
3. the position Y of floating button will be memorized in local storage.